### PR TITLE
Making the household component consistent with current CT-RAMP run, splitting up config

### DIFF
--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -26,7 +26,7 @@
         #"transit"                          
     ]
     global_iteration_components = [
-        #"household",                       # can be called from tm2py
+        "household",                       # can be called from tm2py
         #"internal_external",               # not needed for BART, not tested
         #"truck",                           # Working!!
         #"highway_maz_assign",              # not needed for BART, not tested
@@ -38,6 +38,6 @@
     final_components = []
     start_iteration = 0
     end_iteration = 1
-    host_ip_address = "10.0.166.185"
-    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'
+    host_ip_address = "10.0.143.35"
+    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_P2Y2015'
 	sample_rate_iteration = [0.50]

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -6,8 +6,8 @@
     year = 2015
     verify = false
     #maz_landuse_file = "inputs/landuse/maz_data.csv"
-    landuse_file = "inputs/landuse/maz_data.csv"
-    landuse_index_column = 'ZONE'
+    landuse_file = "inputs/landuse/tazdata.csv"
+    landuse_index_column = 'ZONE' 
 
 [run]
     start_component = ""

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -5,7 +5,9 @@
 [scenario]
     year = 2015
     verify = false
-    maz_landuse_file = "inputs/landuse/maz_data.csv"
+    #maz_landuse_file = "inputs/landuse/maz_data.csv"
+    landuse_file = "inputs/landuse/maz_data.csv"
+    landuse_index_column = 'ZONE'
 
 [run]
     start_component = ""
@@ -34,3 +36,5 @@
     final_components = []
     start_iteration = 0
     end_iteration = 2
+    host_ip_address = "10.13.1.135"
+    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -5,38 +5,36 @@
 [scenario]
     year = 2015
     verify = false
-    landuse_file = "inputs/landuse/tazData.csv"
-    landuse_index_column = "ZONE"
-    landuse_index_in_network_column = "@taz_id"
-    landuse_total_population_column = "TOTPOP"
-    landuse_total_employment_column ="TOTEMP"
-    landuse_total_acre_column = "TOTACRE"
+    landuse_file = "inputs/landuse/maz_data.csv"
+    landuse_index_column = 'ZONE'
 
 [run]
     start_component = ""
     initial_components = [
-        #"create_tod_scenarios",            # working
-        #"active_modes",                    # runs in lasso
-        #"home_accessibility",              # working
-        #"air_passenger",                   # not needed for BART, not tested
-        #"prepare_network_highway",         # Working!!
-        #"highway",                         # Working!!
-        #"highway_maz_skim",                # not needed for BART, not tested
-        #"prepare_network_transit",         # working
-        #"transit"                          
+        #"create_tod_scenarios",
+        #"active_modes",
+        "home_accessibility",
+        "air_passenger",
+        "prepare_network_highway",
+        "highway",
+        "highway_maz_skim",
+        #"prepare_network_transit",
+        #"transit_assign",
+        #"transit_skim"
     ]
     global_iteration_components = [
-        #"household",                       # can be called from tm2py
-        #"internal_external",               # not needed for BART, not tested
-        #"truck",                           # Working!!
-        #"highway_maz_assign",              # not needed for BART, not tested
-        #"prepare_network_highway",         # Working!!
-        #"highway",                         # Working!!
-        #"prepare_network_transit",         # Working
-        "transit"
+        "household",
+        "internal_external",
+        "truck",
+        "highway_maz_assign",
+        "highway",
+        #"prepare_network_transit",
+        #"transit_assign",
+        #"transit_skim"
     ]
     final_components = []
     start_iteration = 0
     end_iteration = 1
-    host_ip_address = "10.0.166.185"
-    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'
+    host_ip_address = "10.0.143.35"
+    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_P2Y2015'
+	sample_rate_iteration = [0.50]

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -5,36 +5,39 @@
 [scenario]
     year = 2015
     verify = false
-    landuse_file = "inputs/landuse/maz_data.csv"
-    landuse_index_column = 'ZONE'
+    landuse_file = "inputs/landuse/tazData.csv"
+    landuse_index_column = "ZONE"
+    landuse_index_in_network_column = "@taz_id"
+    landuse_total_population_column = "TOTPOP"
+    landuse_total_employment_column ="TOTEMP"
+    landuse_total_acre_column = "TOTACRE"
 
 [run]
     start_component = ""
     initial_components = [
-        #"create_tod_scenarios",
-        #"active_modes",
-        "home_accessibility",
-        "air_passenger",
-        "prepare_network_highway",
-        "highway",
-        "highway_maz_skim",
-        #"prepare_network_transit",
-        #"transit_assign",
-        #"transit_skim"
+        #"create_tod_scenarios",            # working
+        #"active_modes",                    # runs in lasso
+        #"home_accessibility",              # working
+        #"air_passenger",                   # not needed for BART, not tested
+        #"prepare_network_highway",         # Working!!
+        #"highway",                         # Working!!
+        #"highway_maz_skim",                # not needed for BART, not tested
+        #"prepare_network_transit",         # working
+        #"transit"                          
     ]
     global_iteration_components = [
-        "household",
-        "internal_external",
-        "truck",
-        "highway_maz_assign",
-        "highway",
-        #"prepare_network_transit",
-        #"transit_assign",
-        #"transit_skim"
+        #"household",                       # can be called from tm2py
+        #"internal_external",               # not needed for BART, not tested
+        #"truck",                           # Working!!
+        #"highway_maz_assign",              # not needed for BART, not tested
+        #"prepare_network_highway",         # Working!!
+        #"highway",                         # Working!!
+        #"prepare_network_transit",         # Working
+        "transit"
     ]
     final_components = []
     start_iteration = 0
     end_iteration = 1
-    host_ip_address = "10.0.143.35"
-    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_P2Y2015'
+    host_ip_address = "10.0.166.185"
+    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'
 	sample_rate_iteration = [0.50]

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -5,36 +5,38 @@
 [scenario]
     year = 2015
     verify = false
-    landuse_file = "inputs/landuse/maz_data.csv"
-    landuse_index_column = 'ZONE'
+    landuse_file = "inputs/landuse/tazData.csv"
+    landuse_index_column = "ZONE"
+    landuse_index_in_network_column = "@taz_id"
+    landuse_total_population_column = "TOTPOP"
+    landuse_total_employment_column ="TOTEMP"
+    landuse_total_acre_column = "TOTACRE"
 
 [run]
     start_component = ""
     initial_components = [
-        #"create_tod_scenarios",
-        #"active_modes",
-        "home_accessibility",
-        "air_passenger",
-        "prepare_network_highway",
-        "highway",
-        "highway_maz_skim",
-        #"prepare_network_transit",
-        #"transit_assign",
-        #"transit_skim"
+        #"create_tod_scenarios",            # working
+        #"active_modes",                    # runs in lasso
+        #"home_accessibility",              # working
+        #"air_passenger",                   # not needed for BART, not tested
+        #"prepare_network_highway",         # Working!!
+        #"highway",                         # Working!!
+        #"highway_maz_skim",                # not needed for BART, not tested
+        #"prepare_network_transit",         # working
+        #"transit"                          
     ]
     global_iteration_components = [
-        "household",
-        "internal_external",
-        "truck",
-        "highway_maz_assign",
-        "highway",
-        #"prepare_network_transit",
-        #"transit_assign",
-        #"transit_skim"
+        #"household",                       # can be called from tm2py
+        #"internal_external",               # not needed for BART, not tested
+        #"truck",                           # Working!!
+        #"highway_maz_assign",              # not needed for BART, not tested
+        #"prepare_network_highway",         # Working!!
+        #"highway",                         # Working!!
+        #"prepare_network_transit",         # Working
+        "transit"
     ]
     final_components = []
     start_iteration = 0
     end_iteration = 1
-    host_ip_address = "10.0.143.35"
-    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_P2Y2015'
-	sample_rate_iteration = [0.50]
+    host_ip_address = "10.0.166.185"
+    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -5,39 +5,36 @@
 [scenario]
     year = 2015
     verify = false
-    landuse_file = "inputs/landuse/tazData.csv"
-    landuse_index_column = "ZONE"
-    landuse_index_in_network_column = "@taz_id"
-    landuse_total_population_column = "TOTPOP"
-    landuse_total_employment_column ="TOTEMP"
-    landuse_total_acre_column = "TOTACRE"
+    landuse_file = "inputs/landuse/maz_data.csv"
+    landuse_index_column = 'ZONE'
 
 [run]
     start_component = ""
     initial_components = [
-        #"create_tod_scenarios",            # working
-        #"active_modes",                    # runs in lasso
-        #"home_accessibility",              # working
-        #"air_passenger",                   # not needed for BART, not tested
-        #"prepare_network_highway",         # Working!!
-        #"highway",                         # Working!!
-        #"highway_maz_skim",                # not needed for BART, not tested
-        #"prepare_network_transit",         # working
-        #"transit"                          
+        #"create_tod_scenarios",
+        #"active_modes",
+        "home_accessibility",
+        "air_passenger",
+        "prepare_network_highway",
+        "highway",
+        "highway_maz_skim",
+        #"prepare_network_transit",
+        #"transit_assign",
+        #"transit_skim"
     ]
     global_iteration_components = [
-        #"household",                       # can be called from tm2py
-        #"internal_external",               # not needed for BART, not tested
-        #"truck",                           # Working!!
-        #"highway_maz_assign",              # not needed for BART, not tested
-        #"prepare_network_highway",         # Working!!
-        #"highway",                         # Working!!
-        #"prepare_network_transit",         # Working
-        "transit"
+        "household",
+        "internal_external",
+        "truck",
+        "highway_maz_assign",
+        "highway",
+        #"prepare_network_transit",
+        #"transit_assign",
+        #"transit_skim"
     ]
     final_components = []
     start_iteration = 0
     end_iteration = 1
-    host_ip_address = "10.0.166.185"
-    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'
+    host_ip_address = "10.0.143.35"
+    ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_P2Y2015'
 	sample_rate_iteration = [0.50]

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -40,3 +40,4 @@
     end_iteration = 1
     host_ip_address = "10.0.166.185"
     ctramp_run_dir = 'C:\MTC_tmpy\TM2\2015_BaseY_PYT2015'
+	sample_rate_iteration = [0.50]

--- a/tests/test_trucks.py
+++ b/tests/test_trucks.py
@@ -9,7 +9,7 @@ def test_commercial_vehicle(examples_dir):
     "Tests that commercial vehicle component can be run."
     from tools import test_component
 
-    my_run = test_component(examples_dir, "truck")
+    my_run = test_component(examples_dir, "truck", 'Link21')
     my_run.run_next()
 
     # TODO write assert

--- a/tests/test_trucks.py
+++ b/tests/test_trucks.py
@@ -9,7 +9,7 @@ def test_commercial_vehicle(examples_dir):
     "Tests that commercial vehicle component can be run."
     from tools import test_component
 
-    my_run = test_component(examples_dir, "truck", 'Link21')
+    my_run = test_component(examples_dir, "truck")
     my_run.run_next()
 
     # TODO write assert

--- a/tests/tools.py
+++ b/tests/tools.py
@@ -47,7 +47,7 @@ def diff_omx(ref_omx: str, run_omx: str) -> Collection[Collection[str]]:
     return missing_matrices, different_matrices
 
 
-def test_component(examples_dir, component, example_name="UnionCity"):
+def test_component(examples_dir, component, example_name="Link21"):
     from tm2py.controller import RunController
 
     base_configs = [

--- a/tm2py/components/demand/air_passenger.py
+++ b/tm2py/components/demand/air_passenger.py
@@ -214,7 +214,7 @@ class AirPassenger(Component):
             airport=airport, year=year, direction=direction
         )
 
-        return self.get_abs_path(self.config.input_demand_folder) / _file_name
+        return self.get_abs_path((self.config.input_demand_folder) / _file_name)
 
     def _get_air_demand_for_year(self, year) -> pd.DataFrame:
         """Creates a dataframe of concatenated data from CSVs for all airport x direction combos.

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -19,17 +19,16 @@ class HouseholdModel(Component):
         """Run the the household resident travel demand model.
 
         Steps:
-            0. Updates (or calculates) telecommute constants
             1. Starts household manager.
             2. Starts matrix manager.
             3. Starts resident travel model (CTRAMP).
             4. Cleans up CTRAMP java.
         """
-        self._update_telecommute_constants()
         self._start_household_manager()
         self._start_matrix_manager()
         self._start_jppf_driver()
         self._start_jppf_node0()
+        self._update_telecommute_constants()
         self._run_resident_model()
         self._stop_java()
 
@@ -38,7 +37,7 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"Household Manager\" java -Xms200m -Xmx20000m -Dlog4j.configuration=log4j_hh.xml com.pb.mtc.ctramp.MtcHouseholdDataManager -hostname %HOST_IP%",
+            "start \"Household Manager\" java -Xms20000m -Xmx20000m -Dlog4j.configuration=log4j_hh.xml com.pb.mtc.ctramp.MtcHouseholdDataManager -hostname %HOST_IP%",
             "echo Hello World"
         ]
         run_process(commands, name="start_household_manager")
@@ -48,13 +47,13 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"Matrix Manager\" java -Xms32000m -Xmx128000m -Dlog4j.configuration=log4j_mtx.xml -Djava.library.path=\"CTRAMP/runtime\" com.pb.models.ctramp.MatrixDataServer -hostname %HOST_IP%",
+            "start \"Matrix Manager\" java -Xms14000m -Xmx140000m -Dlog4j.configuration=log4j_mtx.xml -Djava.library.path=\"CTRAMP/runtime\" com.pb.models.ctramp.MatrixDataServer -hostname %HOST_IP%",
         ]
         run_process(commands, name="start_matrix_manager")
 
     def _run_resident_model(self):
-        sample_rate_iteration_values = self.controller.config.run.sample_rate_iteration
-        sample_rate_iteration = dict(zip(range(1, len(sample_rate_iteration_values) +1), sample_rate_iteration_values))
+        #sample_rate_iteration = {1: 0.3, 2: 0.5, 3: 1, 4: 0.02, 5: 0.02}
+        sample_rate_iteration = {1: 0.01, 2: 0.01}
         iteration = self.controller.iteration
         sample_rate = sample_rate_iteration[iteration]
         seed = 0
@@ -62,7 +61,7 @@ class HouseholdModel(Component):
         commands = [
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
-            "java -showversion -Xmx64000m -cp %CLASSPATH% -Dlog4j.configuration=log4j.xml -Djava.library.path=%RUNTIME% -Djppf.config=jppf-clientDistributed.properties "
+            "java -showversion -Xmx6000m -cp %CLASSPATH% -Dlog4j.configuration=log4j.xml -Djava.library.path=%RUNTIME% -Djppf.config=jppf-clientDistributed.properties "
             "com.pb.mtc.ctramp.MtcTourBasedModel mtcTourBased -iteration {} -sampleRate {} -sampleSeed {}".format(iteration, sample_rate, seed),
         ]
         run_process(commands, name="run_resident_model")
@@ -72,7 +71,7 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"JPPF Server\" java -server -Xmx16000m -Dlog4j.configuration=log4j-driver.properties -Djppf.config=jppf-driver.properties org.jppf.server.DriverLauncher",
+            "start \"JPPF Server\" java -server -Xmx16m -Dlog4j.configuration=log4j-driver.properties -Djppf.config=jppf-driver.properties org.jppf.server.DriverLauncher",
         ]
         run_process(commands, name="start_jppf_driver")
     
@@ -81,7 +80,7 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"Node 0\" java -server -Xmx64000m -Dlog4j.configuration=log4j-node0.xml -Djppf.config=jppf-node0.properties org.jppf.node.NodeLauncher",
+            "start \"Node 0\" java -server -Xmx128m -Dlog4j.configuration=log4j-node0.xml -Djppf.config=jppf-node0.properties org.jppf.node.NodeLauncher",
         ]
         run_process(commands, name="start_jppf_node")
 
@@ -93,10 +92,10 @@ class HouseholdModel(Component):
         commands = [
         "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
         "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
-        ] + [
+        "cd %PYTHON_PATH%",] + [
         f"set {key}={telecommute_parameters[key]}" for key in telecommute_parameters
         ] + [
-        "%PYTHON_PATH%\\python {}\\CTRAMP\\scripts\\preprocess\\updateTelecommuteConstants.py".format(self.controller.config.run.ctramp_run_dir),
-        "copy /Y main\\telecommute_constants_00.csv main\\telecommute_constants.csv"
+        "python CTRAMP\\scripts\\preprocess\\updateTelecommuteConstants.py",
+        "copy /Y main\telecommute_constants_00.csv main\telecommute_constants.csv"
         ]
         run_process(commands, name="update_telecommute_constants")

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -19,16 +19,17 @@ class HouseholdModel(Component):
         """Run the the household resident travel demand model.
 
         Steps:
+            0. Updates (or calculates) telecommute constants
             1. Starts household manager.
             2. Starts matrix manager.
             3. Starts resident travel model (CTRAMP).
             4. Cleans up CTRAMP java.
         """
+        self._update_telecommute_constants()
         self._start_household_manager()
         self._start_matrix_manager()
         self._start_jppf_driver()
         self._start_jppf_node0()
-        self._update_telecommute_constants()
         self._run_resident_model()
         self._stop_java()
 
@@ -37,7 +38,7 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"Household Manager\" java -Xms20000m -Xmx20000m -Dlog4j.configuration=log4j_hh.xml com.pb.mtc.ctramp.MtcHouseholdDataManager -hostname %HOST_IP%",
+            "start \"Household Manager\" java -Xms200m -Xmx20000m -Dlog4j.configuration=log4j_hh.xml com.pb.mtc.ctramp.MtcHouseholdDataManager -hostname %HOST_IP%",
             "echo Hello World"
         ]
         run_process(commands, name="start_household_manager")
@@ -47,13 +48,13 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"Matrix Manager\" java -Xms14000m -Xmx140000m -Dlog4j.configuration=log4j_mtx.xml -Djava.library.path=\"CTRAMP/runtime\" com.pb.models.ctramp.MatrixDataServer -hostname %HOST_IP%",
+            "start \"Matrix Manager\" java -Xms32000m -Xmx128000m -Dlog4j.configuration=log4j_mtx.xml -Djava.library.path=\"CTRAMP/runtime\" com.pb.models.ctramp.MatrixDataServer -hostname %HOST_IP%",
         ]
         run_process(commands, name="start_matrix_manager")
 
     def _run_resident_model(self):
-        #sample_rate_iteration = {1: 0.3, 2: 0.5, 3: 1, 4: 0.02, 5: 0.02}
-        sample_rate_iteration = {1: 0.01, 2: 0.01}
+        sample_rate_iteration_values = self.controller.config.run.sample_rate_iteration
+        sample_rate_iteration = dict(zip(range(1, len(sample_rate_iteration_values) +1), sample_rate_iteration_values))
         iteration = self.controller.iteration
         sample_rate = sample_rate_iteration[iteration]
         seed = 0
@@ -61,7 +62,7 @@ class HouseholdModel(Component):
         commands = [
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
-            "java -showversion -Xmx6000m -cp %CLASSPATH% -Dlog4j.configuration=log4j.xml -Djava.library.path=%RUNTIME% -Djppf.config=jppf-clientDistributed.properties "
+            "java -showversion -Xmx64000m -cp %CLASSPATH% -Dlog4j.configuration=log4j.xml -Djava.library.path=%RUNTIME% -Djppf.config=jppf-clientDistributed.properties "
             "com.pb.mtc.ctramp.MtcTourBasedModel mtcTourBased -iteration {} -sampleRate {} -sampleSeed {}".format(iteration, sample_rate, seed),
         ]
         run_process(commands, name="run_resident_model")
@@ -71,7 +72,7 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"JPPF Server\" java -server -Xmx16m -Dlog4j.configuration=log4j-driver.properties -Djppf.config=jppf-driver.properties org.jppf.server.DriverLauncher",
+            "start \"JPPF Server\" java -server -Xmx16000m -Dlog4j.configuration=log4j-driver.properties -Djppf.config=jppf-driver.properties org.jppf.server.DriverLauncher",
         ]
         run_process(commands, name="start_jppf_driver")
     
@@ -80,7 +81,7 @@ class HouseholdModel(Component):
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
-            "start \"Node 0\" java -server -Xmx128m -Dlog4j.configuration=log4j-node0.xml -Djppf.config=jppf-node0.properties org.jppf.node.NodeLauncher",
+            "start \"Node 0\" java -server -Xmx64000m -Dlog4j.configuration=log4j-node0.xml -Djppf.config=jppf-node0.properties org.jppf.node.NodeLauncher",
         ]
         run_process(commands, name="start_jppf_node")
 
@@ -92,10 +93,10 @@ class HouseholdModel(Component):
         commands = [
         "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
         "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
-        "cd %PYTHON_PATH%",] + [
+        ] + [
         f"set {key}={telecommute_parameters[key]}" for key in telecommute_parameters
         ] + [
-        "python CTRAMP\\scripts\\preprocess\\updateTelecommuteConstants.py",
-        "copy /Y main\telecommute_constants_00.csv main\telecommute_constants.csv"
+        "%PYTHON_PATH%\\python {}\\CTRAMP\\scripts\\preprocess\\updateTelecommuteConstants.py".format(self.controller.config.run.ctramp_run_dir),
+        "copy /Y main\\telecommute_constants_00.csv main\\telecommute_constants.csv"
         ]
         run_process(commands, name="update_telecommute_constants")

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -34,9 +34,7 @@ class HouseholdModel(Component):
 
     def _start_household_manager(self):
         commands = [
-            #"cd /d {}".format(self.controller.run_dir.__str__()),
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
-            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
             "start \"Household Manager\" java -Xms20000m -Xmx20000m -Dlog4j.configuration=log4j_hh.xml com.pb.mtc.ctramp.MtcHouseholdDataManager -hostname %HOST_IP%",
@@ -46,8 +44,6 @@ class HouseholdModel(Component):
 
     def _start_matrix_manager(self):
         commands = [
-            #"cd /d {}".format(self.controller.run_dir.__str__()),
-            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
@@ -63,8 +59,6 @@ class HouseholdModel(Component):
         seed = 0
         
         commands = [
-            #"cd /d {}".format(self.controller.run_dir.__str__()),
-            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "java -showversion -Xmx6000m -cp %CLASSPATH% -Dlog4j.configuration=log4j.xml -Djava.library.path=%RUNTIME% -Djppf.config=jppf-clientDistributed.properties "
@@ -74,8 +68,6 @@ class HouseholdModel(Component):
     
     def _start_jppf_driver(self):
         commands = [
-            #"cd /d {}".format(self.controller.run_dir.__str__()),
-            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
@@ -85,8 +77,6 @@ class HouseholdModel(Component):
     
     def _start_jppf_node0(self):
         commands = [
-            #"cd /d {}".format(self.controller.run_dir.__str__()),
-            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
             "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
             "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
@@ -98,8 +88,13 @@ class HouseholdModel(Component):
         run_process(['taskkill /im "java.exe" /F'])
     
     def _update_telecommute_constants(self):
+        telecommute_parameters = {'ITER':0, 'MODEL_YEAR': 2015, 'MODEL_DIR': self.controller.config.run.ctramp_run_dir}
         commands = [
         "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+        "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
+        "cd %PYTHON_PATH%",] + [
+        f"set {key}={telecommute_parameters[key]}" for key in telecommute_parameters
+        ] + [
         "python CTRAMP\scripts\preprocess\updateTelecommuteConstants.py",
         "copy /Y main\telecommute_constants_00.csv main\telecommute_constants.csv"
         ]

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -95,7 +95,7 @@ class HouseholdModel(Component):
         "cd %PYTHON_PATH%",] + [
         f"set {key}={telecommute_parameters[key]}" for key in telecommute_parameters
         ] + [
-        "python CTRAMP\scripts\preprocess\updateTelecommuteConstants.py",
+        "python CTRAMP\\scripts\\preprocess\\updateTelecommuteConstants.py",
         "copy /Y main\telecommute_constants_00.csv main\telecommute_constants.csv"
         ]
         run_process(commands, name="update_telecommute_constants")

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -52,8 +52,7 @@ class HouseholdModel(Component):
         run_process(commands, name="start_matrix_manager")
 
     def _run_resident_model(self):
-        #sample_rate_iteration = {1: 0.3, 2: 0.5, 3: 1, 4: 0.02, 5: 0.02}
-        sample_rate_iteration = {1: 0.01, 2: 0.01}
+        sample_rate_iteration = self.controller.config.run.sample_rate_iteration
         iteration = self.controller.iteration
         sample_rate = sample_rate_iteration[iteration]
         seed = 0
@@ -96,6 +95,6 @@ class HouseholdModel(Component):
         f"set {key}={telecommute_parameters[key]}" for key in telecommute_parameters
         ] + [
         "python CTRAMP\\scripts\\preprocess\\updateTelecommuteConstants.py",
-        "copy /Y main\telecommute_constants_00.csv main\telecommute_constants.csv"
+        "copy /Y main\\telecommute_constants_00.csv main\\telecommute_constants.csv"
         ]
         run_process(commands, name="update_telecommute_constants")

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -28,13 +28,16 @@ class HouseholdModel(Component):
         self._start_matrix_manager()
         self._start_jppf_driver()
         self._start_jppf_node0()
+        self._update_telecommute_constants()
         self._run_resident_model()
         self._stop_java()
 
     def _start_household_manager(self):
         commands = [
-            "cd /d {}".format(self.controller.run_dir.__str__()),
-            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            #"cd /d {}".format(self.controller.run_dir.__str__()),
+            "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
             "start \"Household Manager\" java -Xms20000m -Xmx20000m -Dlog4j.configuration=log4j_hh.xml com.pb.mtc.ctramp.MtcHouseholdDataManager -hostname %HOST_IP%",
             "echo Hello World"
@@ -43,22 +46,27 @@ class HouseholdModel(Component):
 
     def _start_matrix_manager(self):
         commands = [
-            "cd /d {}".format(self.controller.run_dir.__str__()),
-            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            #"cd /d {}".format(self.controller.run_dir.__str__()),
+            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
             "start \"Matrix Manager\" java -Xms14000m -Xmx140000m -Dlog4j.configuration=log4j_mtx.xml -Djava.library.path=\"CTRAMP/runtime\" com.pb.models.ctramp.MatrixDataServer -hostname %HOST_IP%",
         ]
         run_process(commands, name="start_matrix_manager")
 
     def _run_resident_model(self):
-        sample_rate_iteration = {1: 0.3, 2: 0.5, 3: 1, 4: 0.02, 5: 0.02}
+        #sample_rate_iteration = {1: 0.3, 2: 0.5, 3: 1, 4: 0.02, 5: 0.02}
+        sample_rate_iteration = {1: 0.01, 2: 0.01}
         iteration = self.controller.iteration
         sample_rate = sample_rate_iteration[iteration]
         seed = 0
-        #_shutil.copyfile("CTRAMP\\runtime\\mtctm2.properties", "mtctm2.properties")
+        
         commands = [
-            "cd /d {}".format(self.controller.run_dir.__str__()),
-            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            #"cd /d {}".format(self.controller.run_dir.__str__()),
+            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "java -showversion -Xmx6000m -cp %CLASSPATH% -Dlog4j.configuration=log4j.xml -Djava.library.path=%RUNTIME% -Djppf.config=jppf-clientDistributed.properties "
             "com.pb.mtc.ctramp.MtcTourBasedModel mtcTourBased -iteration {} -sampleRate {} -sampleSeed {}".format(iteration, sample_rate, seed),
         ]
@@ -66,8 +74,10 @@ class HouseholdModel(Component):
     
     def _start_jppf_driver(self):
         commands = [
-            "cd /d {}".format(self.controller.run_dir.__str__()),
-            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            #"cd /d {}".format(self.controller.run_dir.__str__()),
+            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
             "start \"JPPF Server\" java -server -Xmx16m -Dlog4j.configuration=log4j-driver.properties -Djppf.config=jppf-driver.properties org.jppf.server.DriverLauncher",
         ]
@@ -75,8 +85,10 @@ class HouseholdModel(Component):
     
     def _start_jppf_node0(self):
         commands = [
-            "cd /d {}".format(self.controller.run_dir.__str__()),
-            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            #"cd /d {}".format(self.controller.run_dir.__str__()),
+            #"CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.run_dir.__str__()),
+            "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+            "CALL {}\\CTRAMP\\runtime\\SetPath.bat".format(self.controller.config.run.ctramp_run_dir),
             "set HOST_IP={}".format(self.controller.config.run.host_ip_address),
             "start \"Node 0\" java -server -Xmx128m -Dlog4j.configuration=log4j-node0.xml -Djppf.config=jppf-node0.properties org.jppf.node.NodeLauncher",
         ]
@@ -84,3 +96,11 @@ class HouseholdModel(Component):
 
     def _stop_java(self):
         run_process(['taskkill /im "java.exe" /F'])
+    
+    def _update_telecommute_constants(self):
+        commands = [
+        "cd /d {}".format(self.controller.config.run.ctramp_run_dir),
+        "python CTRAMP\scripts\preprocess\updateTelecommuteConstants.py",
+        "copy /Y main\telecommute_constants_00.csv main\telecommute_constants.csv"
+        ]
+        run_process(commands, name="update_telecommute_constants")

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -51,10 +51,6 @@ class ScenarioConfig(ConfigItem):
 
     landuse_file: pathlib.Path
     landuse_index_column: str
-    landuse_index_in_network_column: str
-    landuse_total_population_column: str
-    landuse_total_employment_column: str
-    landuse_total_acre_column: str
     year: int = Field(ge=2005)
     verify: Optional[bool] = Field(default=False)
 
@@ -68,7 +64,6 @@ ComponentNames = Literal[
     "highway_maz_assign",
     "highway",
     "highway_maz_skim",
-    "prepare_network_transit",
     "transit",
     "household",
     "visitor",
@@ -100,6 +95,7 @@ class RunConfig(ConfigItem):
     final_components: Tuple[ComponentNames, ...]
     ctramp_run_dir: str
     host_ip_address: str
+    sample_rate_iteration: list
     start_iteration: int = Field(ge=0)
     end_iteration: int = Field(gt=0)
     start_component: Optional[Union[ComponentNames, EmptyString]] = Field(default="")
@@ -982,7 +978,7 @@ class HighwayConfig(ConfigItem):
 class TransitModeConfig(ConfigItem):
     """Transit mode definition (see also mode in the Emme API)."""
 
-    type: Literal["WALK", "ACCESS", "EGRESS", "LOCAL", "PREMIUM", "PNR", "KNR"]
+    type: Literal["WALK", "ACCESS", "EGRESS", "LOCAL", "PREMIUM"]
     assign_type: Literal["TRANSIT", "AUX_TRANSIT"]
     mode_id: str = Field(min_length=1, max_length=1)
     name: str = Field(max_length=10)
@@ -1047,21 +1043,13 @@ class TransitConfig(ConfigItem):
     fare_matrix_path: pathlib.Path
     fare_max_transfer_distance_miles: float
     use_fares: bool
-    override_connectors: bool
     override_connector_times: bool
     input_connector_access_times_path: Optional[pathlib.Path] = Field(default=None)
     input_connector_egress_times_path: Optional[pathlib.Path] = Field(default=None)
     output_stop_usage_path: Optional[pathlib.Path] = Field(default=None)
     output_skim_filename_tmpl: str = Field()
     output_skim_matrixname_tmpl: str = Field()
-    output_transit_boardings_path: str = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
-    use_ccr: bool = False
-    congested_transit_assignment: bool = False
-    capacitated_transit_assignment: bool = False
-    station_capacity_transit_assignment: bool = False
-    mask_noncombo_allpen: bool = False
-    mask_over_3_xfers: bool = False
 
 @dataclass(frozen=True)
 class EmmeConfig(ConfigItem):

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -51,6 +51,10 @@ class ScenarioConfig(ConfigItem):
 
     landuse_file: pathlib.Path
     landuse_index_column: str
+    landuse_index_in_network_column: str
+    landuse_total_population_column: str
+    landuse_total_employment_column: str
+    landuse_total_acre_column: str
     year: int = Field(ge=2005)
     verify: Optional[bool] = Field(default=False)
 
@@ -64,6 +68,7 @@ ComponentNames = Literal[
     "highway_maz_assign",
     "highway",
     "highway_maz_skim",
+    "prepare_network_transit",
     "transit",
     "household",
     "visitor",
@@ -95,7 +100,6 @@ class RunConfig(ConfigItem):
     final_components: Tuple[ComponentNames, ...]
     ctramp_run_dir: str
     host_ip_address: str
-    sample_rate_iteration: list
     start_iteration: int = Field(ge=0)
     end_iteration: int = Field(gt=0)
     start_component: Optional[Union[ComponentNames, EmptyString]] = Field(default="")
@@ -978,7 +982,7 @@ class HighwayConfig(ConfigItem):
 class TransitModeConfig(ConfigItem):
     """Transit mode definition (see also mode in the Emme API)."""
 
-    type: Literal["WALK", "ACCESS", "EGRESS", "LOCAL", "PREMIUM"]
+    type: Literal["WALK", "ACCESS", "EGRESS", "LOCAL", "PREMIUM", "PNR", "KNR"]
     assign_type: Literal["TRANSIT", "AUX_TRANSIT"]
     mode_id: str = Field(min_length=1, max_length=1)
     name: str = Field(max_length=10)
@@ -1043,13 +1047,21 @@ class TransitConfig(ConfigItem):
     fare_matrix_path: pathlib.Path
     fare_max_transfer_distance_miles: float
     use_fares: bool
+    override_connectors: bool
     override_connector_times: bool
     input_connector_access_times_path: Optional[pathlib.Path] = Field(default=None)
     input_connector_egress_times_path: Optional[pathlib.Path] = Field(default=None)
     output_stop_usage_path: Optional[pathlib.Path] = Field(default=None)
     output_skim_filename_tmpl: str = Field()
     output_skim_matrixname_tmpl: str = Field()
+    output_transit_boardings_path: str = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
+    use_ccr: bool = False
+    congested_transit_assignment: bool = False
+    capacitated_transit_assignment: bool = False
+    station_capacity_transit_assignment: bool = False
+    mask_noncombo_allpen: bool = False
+    mask_over_3_xfers: bool = False
 
 @dataclass(frozen=True)
 class EmmeConfig(ConfigItem):

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -100,6 +100,7 @@ class RunConfig(ConfigItem):
     final_components: Tuple[ComponentNames, ...]
     ctramp_run_dir: str
     host_ip_address: str
+    sample_rate_iteration: list
     start_iteration: int = Field(ge=0)
     end_iteration: int = Field(gt=0)
     start_component: Optional[Union[ComponentNames, EmptyString]] = Field(default="")

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -93,6 +93,7 @@ class RunConfig(ConfigItem):
     initial_components: Tuple[ComponentNames, ...]
     global_iteration_components: Tuple[ComponentNames, ...]
     final_components: Tuple[ComponentNames, ...]
+    ctramp_run_dir: str
     host_ip_address: str
     start_iteration: int = Field(ge=0)
     end_iteration: int = Field(gt=0)


### PR DESCRIPTION
(Please keep ``develop_bart_wip`` in the repo, thanks!)

## What existing problem does the pull request solve and why should we include it?
The household component under ``develop_bart`` fails because it doesn't call the telecommute constant updater script before each iteration. It also tries to pick up inputs from the UnionCity example folder whereas CT-RAMP run inputs (involving no Emme files) are usually stored separately (or, CS is not ready to merge the input folders at this point). This code adds a module to perform telecommute constant updates, and includes other minor changes that refactor CT-RAMP-specific parameters.

## What is the testing plan?
CS has tested the code in two machines, including a local computer and and an AWS machine. It calls CT-RAMP and performs the run as intended.

 - [x] Code for this PR is covered in tests 
 - [ ] Code passes all existing tests