### PR TITLE
Updates to accessibility calculations, household model, convergence metric config, typos

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -82,7 +82,7 @@
         8 = 'knr'
         9 = 'RIDEHAIL'
 	[household.income_segment]
-        enabled = false
+        enabled = true
         segment_suffixes = ["LowInc", "MedInc", "HighInc", "XHighInc"]
         cutoffs = [0, 30000, 60000, 100000]
 
@@ -99,10 +99,10 @@
     [accessibility.formula_auto]
         # second element of list contains matrices to be transposed
         # formatted as a list of [mode name, time period]
-        "peak" = [[['da','AM']],
-            [['da', 'PM']]]
-        "offpeak" = [[['da','MD']],
-            [['da', 'MD']]]
+        "peak" = [[['dah','AM']],
+            [['dah', 'PM']]]
+        "offpeak" = [[['dah','MD']],
+            [['dah', 'MD']]]
         "prop" = 'TIME'
     [accessibility.formula_transit]
         "peak" = [[['wlk_trn_wlk','AM']],
@@ -882,11 +882,27 @@
 		output_triptable_path = "output_summaries/trip_tables_{iteration}.omx"
 		output_skim_path = "output_summaries/skims_{iteration}.omx"
 		selected_od_pair = [1,100]
-		selected_links = [5,10,15]
 		skim_selected_time_periods = ["am","pm"]
 		ft_types = [1,2,4,5,6]
 		output_network_attr_filename = "output_summaries/network_attrs_{iteration}.parquet"
 		output_network_summary_filename = "output_summaries/network_summary_{iteration}.csv"
+		
+		[highway.convergence.selected_links]
+			38545="Bay Bridge west span (eastbound)"
+			4166="Bay Bridge west span (westbound)"
+			3087470="I-80 corridor between Richmond and Oakland (southbound)"
+			3149662="I-80 corridor between Richmond and Oakland (northbound)"
+			4045624="I-80 corridor between Richmond and Oakland (southbound)"
+			4089555="I-80 corridor between Richmond and Oakland (northbound)"
+			3057003="580 between Pleasanton and Livermore (westbound)"
+			3160653="580 between Pleasanton and Livermore (eastbound)"
+			1034144="101 between SF and San Mateo County (southbound)"
+			1040116="101 between SF and San Mateo County (northbound)"
+			1048514="280 between SF and San Mateo County (southbound)"
+			1070169="280 between SF and San Mateo County (northbound)"
+			3055218="I-880 between hayward and fremont parallel to BART services (northbound)"
+			3004982="I-880 between hayward and fremont parallel to BART services (southbound)"
+		
 		[[highway.convergence.summary_mode_group]]
 			name = "KNR Transit"
 			modes = ["KNR_TRN_WLK", "WLK_TRN_KNR"]
@@ -904,7 +920,9 @@
 			modes = ["s2", "s3"]
 		[[highway.convergence.summary_mode_group]]
 			name = "Drive alone"
-			modes = ["da"]
+			modes = ["dah"]
+		
+		
 
 [transit]
     apply_msa_demand = false

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -884,6 +884,7 @@
 		selected_od_pair = [1,100]
 		selected_links = [5,10,15]
 		skim_selected_time_periods = ["am","pm"]
+		ft_types = [1,2,4,5,6]
 		output_network_attr_filename = "output_summaries/network_attrs_{iteration}.parquet"
 		output_network_summary_filename = "output_summaries/network_summary_{iteration}.csv"
 		[[highway.convergence.summary_mode_group]]

--- a/tm2py/components/access.py
+++ b/tm2py/components/access.py
@@ -115,7 +115,9 @@ class HomeAccessibility(Component):
             Or part of network.skims?
         """
         _ref_scenario_id = self.controller.config.time_periods[0].emme_scenario_id
-        return self.emmebank.scenario(_ref_scenario_id)
+        if self.emmebank.scenario(_ref_scenario_id):
+            return self.emmebank.scenario(_ref_scenario_id)
+        return self.emmebank.scenario(1)
 
     @property
     def employment_df(self):
@@ -128,8 +130,8 @@ class HomeAccessibility(Component):
         if skim_prop is None:
             skim_prop = formulas['prop']
         if mode == 'auto':
-            return np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop) for matrix in formulas[time_period][0]]) + \
-                np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop) for matrix in formulas[time_period][1]]).T
+            return np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop, force_read = ['highway', 'da']) for matrix in formulas[time_period][0]]) + \
+                np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop, force_read =  ['highway', 'da']) for matrix in formulas[time_period][1]]).T
         elif mode == 'transit':
             ivt_matrix_names = [dict(zip(['skim_mode','time_period','property'], matrix_name[0] + [matrix_name[1]])) for matrix_name in itertools.product(formulas[time_period][0], formulas['ivt'])]
             ivt_matrix_names_T = [dict(zip(['skim_mode','time_period','property'], matrix_name[0] + [matrix_name[1]])) for matrix_name in itertools.product(formulas[time_period][1], formulas['ivt'])]

--- a/tm2py/components/access.py
+++ b/tm2py/components/access.py
@@ -130,8 +130,8 @@ class HomeAccessibility(Component):
         if skim_prop is None:
             skim_prop = formulas['prop']
         if mode == 'auto':
-            return np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop, force_read = ['highway', 'da']) for matrix in formulas[time_period][0]]) + \
-                np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop, force_read =  ['highway', 'da']) for matrix in formulas[time_period][1]]).T
+            return np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop) for matrix in formulas[time_period][0]]) + \
+                np.add.reduce([get_omx_skim_as_numpy(self.controller, *matrix, property=skim_prop) for matrix in formulas[time_period][1]]).T
         elif mode == 'transit':
             ivt_matrix_names = [dict(zip(['skim_mode','time_period','property'], matrix_name[0] + [matrix_name[1]])) for matrix_name in itertools.product(formulas[time_period][0], formulas['ivt'])]
             ivt_matrix_names_T = [dict(zip(['skim_mode','time_period','property'], matrix_name[0] + [matrix_name[1]])) for matrix_name in itertools.product(formulas[time_period][1], formulas['ivt'])]

--- a/tm2py/components/demand/household.py
+++ b/tm2py/components/demand/household.py
@@ -144,12 +144,18 @@ class HouseholdModel(Component):
 
     def _run_resident_model(self):
         sample_rate_iteration_values = self.controller.config.household.sample_rate_iteration
-        if len(sample_rate_iteration_values) != self.controller.config.run.end_iteration - self.controller.config.run.start_iteration + 1:
-            raise Exception("The length of sample rate values does not match the number of iterations.")
-        
-        sample_rate_iteration = dict(zip(
-            range(self.controller.config.run.start_iteration, self.controller.config.run.end_iteration + 1), 
-            sample_rate_iteration_values))
+        if self.controller.config.run.start_iteration != 0:
+            if len(sample_rate_iteration_values) != self.controller.config.run.end_iteration - self.controller.config.run.start_iteration + 1:
+                raise Exception("The length of sample rate values does not match the number of iterations.")
+            sample_rate_iteration = dict(zip(
+                range(self.controller.config.run.start_iteration, self.controller.config.run.end_iteration + 1), 
+                sample_rate_iteration_values))
+        else:
+            if len(sample_rate_iteration_values) != self.controller.config.run.end_iteration - self.controller.config.run.start_iteration:
+                raise Exception("The length of sample rate values does not match the number of iterations.")
+            sample_rate_iteration = dict(zip(
+                range(self.controller.config.run.start_iteration + 1, self.controller.config.run.end_iteration + 1), 
+                sample_rate_iteration_values))
         
         iteration = self.controller.iteration
         sample_rate = sample_rate_iteration[iteration]

--- a/tm2py/components/network/skims.py
+++ b/tm2py/components/network/skims.py
@@ -57,7 +57,6 @@ def get_omx_skim_as_numpy(
     time_period: str,
     property: str = "time",
     omx_manager: OMXManager = None,
-    force_read: list = None
 ) -> NumpyArray:
     """Get OMX skim by time and mode from folder and return a zone-to-zone NumpyArray.
 
@@ -69,7 +68,6 @@ def get_omx_skim_as_numpy(
         mode: Mode to get.
         time_period: Time period to get.
         property: Property to get. Defaults to "time".
-        force_read: in case of config skim mode and assignment mode mismatch, provides mode class (highway/transit,active) and skim mode name. (e.g., ['highway', 'DA'])
     """
 
     if time_period.upper() not in controller.time_period_names:
@@ -82,65 +80,24 @@ def get_omx_skim_as_numpy(
     _trn_classes = {c.name: c for c in controller.config.transit.classes}
     _nm_classes = {c.name: c for c in controller.config.active_modes.classes}
 
+    if skim_mode in _hwy_classes.keys():
+        _config = controller.config.highway
+        _mode_config = _hwy_classes[skim_mode]
+    elif skim_mode in _trn_classes.keys():
+        _config = controller.config.transit
+        _mode_config = _trn_classes[skim_mode]
+    elif skim_mode in _nm_classes.keys():
+        _config = controller.config.active_modes
+        _mode_config = _nm_classes[skim_mode]
 
-    if force_read:
-        if force_read[0] == 'highway':
-            _config = controller.config.highway
-            _matrix_name = _config.output_skim_matrixname_tmpl.format(
-                class_name=force_read[1],
-                property_name=property,
-            )
-            _filename = _config.output_skim_filename_tmpl.format(
-                time_period=time_period.lower()
-            )
-        
-        elif force_read[0] == 'transit':
-            _config = controller.config.transit
-            _matrix_name = _config.output_skim_matrixname_tmpl.format(
-                time_period=time_period.lower(),
-                mode =force_read[1],
-                property=property
-            )
-            _filename = _config.output_skim_filename_tmpl.format(
-                time_period=time_period,
-                set_name = force_read[1],
-            )
-        
-            
-        elif force_read[0] == 'active_modes':
-            _config = controller.config.active_modes
-            _matrix_name = _config.output_skim_matrixname_tmpl.format(
-                time_period=time_period.lower(),
-                mode=force_read[1],
-                property=property
-            )
-            _filename = _config.output_skim_filename_tmpl.format(
-                time_period=time_period,
-                mode = force_read[1],
-            )
-            
-            
     else:
-        if skim_mode in _hwy_classes.keys():
-            _config = controller.config.highway
-            _mode_config = _hwy_classes[skim_mode]
-        
-        elif skim_mode in _trn_classes.keys():
-            _config = controller.config.transit
-            _mode_config = _trn_classes[skim_mode]
-        
-        elif skim_mode in _nm_classes.keys():
-            _config = controller.config.active_modes
-            _mode_config = _nm_classes[skim_mode]
-        
-        else:
-            raise NotImplementedError("Haven't implemented non highway/transit/non-motorized skim access")
+        raise NotImplementedError("Haven't implemented non highway/transit/non-motorized skim access")
 
-        if property not in list(_mode_config["skims"]) + [e.upper() for e in _mode_config["skims"]]: #TODO: this needs to be case-insensitive
-            raise ValueError(
-                f"Property {property} not an available skim in mode {skim_mode}.\
-                Available skims are:  {_mode_config['skims']}"
-            )
+    if property not in list(_mode_config["skims"]) + [e.upper() for e in _mode_config["skims"]]: #TODO: this needs to be case-insensitive
+        raise ValueError(
+            f"Property {property} not an available skim in mode {skim_mode}.\
+            Available skims are:  {_mode_config['skims']}"
+        )
 
     if skim_mode in _hwy_classes.keys():
         _matrix_name = _config.output_skim_matrixname_tmpl.format(

--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -1384,7 +1384,7 @@ class TransitAssignment(Component):
             )
             omx_file_path = os.path.join(
                 output_skim_path,
-                self.controller.config.transit.output_skim_filename_tmpl.format(period=period, set_name=set_name))
+                self.controller.config.transit.output_skim_filename_tmpl.format(time_period=period, set_name=set_name))
             os.makedirs(os.path.dirname(omx_file_path), exist_ok=True)
 
             for skim in _skim_names:

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -941,12 +941,13 @@ class ConvergenceReportConfig(ConfigItem):
     output_triptable_path: str = Field()
     output_skim_path: str = Field()
     selected_od_pair: Tuple[int, ...] = Field()
-    selected_links: Tuple[int, ...] = Field()
     ft_types: Tuple[int, ...] = Field()
     skim_selected_time_periods: Tuple[str, ...] = Field()
     output_network_attr_filename: str = Field()
     output_network_summary_filename: str = Field()
     summary_mode_group: Tuple[ConvergenceReportModeGroupConfig, ...] = Field()
+    selected_links: Dict[float, str] = Field()
+    
 
 
 @dataclass(frozen=True)

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -809,7 +809,6 @@ class HighwayTollsConfig(ConfigItem):
     dst_vehicle_group_names: Tuple[str, ...] = Field()
     run_dynamic_toll: bool = Field(default=False)
     max_dynamic_valuetoll: float = Field()
-    bridetoll_file_path: pathlib.Path = Field()
 
     @validator("dst_vehicle_group_names", always=True)
     def dst_vehicle_group_names_length(value, values):
@@ -1165,7 +1164,7 @@ class TransitConfig(ConfigItem):
     initial_wait_perception_factor: float
     transfer_wait_perception_factor: float
     walk_perception_factor: float
-    #drive_perception_factor: float
+    drive_perception_factor: float
     
     max_transfers: int
     output_skim_path: pathlib.Path


### PR DESCRIPTION
The home_accessibility module was no longer compatible with the recent changes to the highway and transit assignment scripts, specifically income segmentation and transit skim file name template. This PR includes a commit that fixes these issues.

Income segmentation: A "force_read" mechanism is added to skims.py so that the accessibility calculator can always pick up the highway DA skims.
Transit skim file name template: in the 'export_skims' method in transit.py, reversed {period} back to {time_period}.

In addition, this PR includes the following changes:
- The length of sample rate values has to match the number of iterations. A code change was made to handle the case where start_iteration = 0.
- The user can now specify facility types to be included in the convergence report.
- Typos introduced in previous commits were fixed in config.py.