### PR TITLE
Update warmstart behavior in highway assignment

### DIFF
--- a/tm2py/components/network/highway/highway_assign.py
+++ b/tm2py/components/network/highway/highway_assign.py
@@ -135,7 +135,7 @@ class HighwayAssignment(Component):
             with self._setup(scenario, time):
                 iteration = self.controller.iteration
                 assign_classes = [
-                    AssignmentClass(c, time, iteration) for c in self.config.classes
+                    AssignmentClass(c, time, iteration, self.controller.config.run.warmstart.warmstart) for c in self.config.classes
                 ]
                 if (iteration > 0) & (self.controller.config.highway.run_maz_assignment):
                     self._copy_maz_flow(scenario)
@@ -254,7 +254,7 @@ class HighwayAssignment(Component):
         write_iteration_flow = self.controller.config.highway.msa.write_iteration_flow
         net_calc = NetworkCalculator(scenario)
 
-        if iteration == 1 or ( (iteration == 0) & self.controller.config.run.warmstart): 
+        if iteration == 1 or ( (iteration == 0) & self.controller.config.run.warmstart.warmstart): 
             # carry over current flow to the averaged flow attribute
             net_calc("@total_flow_avg", "@total_flow")
             for assign_class in self.config.classes:
@@ -273,7 +273,7 @@ class HighwayAssignment(Component):
                 net_calc(f"@flow_{assign_class.name.lower()}", f"@flow_{assign_class.name.lower()}_avg")
 
         # write out iteration total flow and flow by class
-        if (iteration >= 1 or self.controller.config.run.warmstart) and write_iteration_flow:
+        if (iteration >= 1 or self.controller.config.run.warmstart.warmstart) and write_iteration_flow:
             net_calc(f"@total_flow_{iteration}", "@total_flow")
             for assign_class in self.config.classes:
                 net_calc(f"@flow_{assign_class.name.lower()}_{iteration}", f"@flow_{assign_class.name.lower()}")
@@ -461,17 +461,19 @@ class HighwayAssignment(Component):
 class AssignmentClass:
     """Highway assignment class, represents data from config and conversion to Emme specs."""
 
-    def __init__(self, class_config, time_period, iteration):
+    def __init__(self, class_config, time_period, iteration, warmstart):
         """Constructor of Highway Assignment class.
 
         Args:
             class_config (_type_): _description_
             time_period (_type_): _description_
             iteration (_type_): _description_
+            warmstart (Boolean): warmstart switch
         """
         self.class_config = class_config
         self.time_period = time_period
         self.iteration = iteration
+        self.warmstart = warmstart
         self.name = class_config["name"].lower()
         self.skims = class_config.get("skims", [])
 
@@ -487,7 +489,7 @@ class AssignmentClass:
             A nested dictionary corresponding to the expected Emme traffic
             class specification used in the SOLA assignment.
         """
-        if self.iteration == 0 and not self.controller.config.run.warmstart:
+        if (self.iteration == 0) and not self.warmstart:
             demand_matrix = 'ms"zero"'
         else:
             demand_matrix = f'mf"{self.time_period}_{self.name}"'

--- a/tm2py/controller.py
+++ b/tm2py/controller.py
@@ -235,9 +235,9 @@ class RunController:
         Iterates through the self._queued_components and runs them.
         """
         self._iteration = None
-        if self.config.run.warmstart and self.config.run.warmstart_check and self.config.run.start_iteration == 0:
+        if self.config.run.warmstart.warmstart and self.config.run.warmstart.warmstart_check and (self.config.run.start_iteration == 0):
             self.warmstart_check()
-        if self.config.run.warmstart & self.config.run.start_iteration == 0:
+        if self.config.run.warmstart.warmstart and (self.config.run.start_iteration == 0):
             self.copy_warmstart_demand()
         while self._queued_components:
             self.run_next()


### PR DESCRIPTION
The highway assignment class wasn't able to respond to warmstart settings. The class definition has been updated so the user can pass a warmstart argument that affects whether zero demand is used. 

The code change has been tested with four different scenario config files, with highway assignment run in iteration 0 vs. iteration 1, and warmstart turned on vs. off.

@vivekyadav26 This completes the test run we discussed in the morning.