### PR TITLE
fix bugs in export to shapefile function

### DIFF
--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -154,6 +154,11 @@ class TransitAssignment(Component):
         """Run transit assignment and skims."""
         project_path = self.get_abs_path(self.controller.config.emme.project_path)
         emme_app = self.controller.emme_manager.project(project_path)
+        data_explorer = emme_app.data_explorer()
+        all_databases = data_explorer.databases()
+        for database in all_databases:
+            if "transit" in database.name():
+                database.open()
         if not os.path.isabs(self.controller.config.emme.transit_database_path):
             emmebank_path = self.get_abs_path(self.controller.config.emme.transit_database_path)
         emmebank = self.controller.emme_manager.emmebank(emmebank_path)
@@ -261,7 +266,7 @@ class TransitAssignment(Component):
                 if self.controller.config.transit.get("output_transit_boardings_path"):
                     self.export_boardings_by_line(scenario, period, use_fares)
                 if self.controller.config.transit.get("output_shapefile_path"):
-                    emme_app.data_explorer().replace_primary_scenario(scenario)
+                    data_explorer.replace_primary_scenario(scenario)
                     self.export_segment_shapefile(emme_app, period)
                 if self.controller.config.transit.get("output_stop_usage_path"):
                     self.export_connector_flows(scenario, period)


### PR DESCRIPTION
## What existing problem does the pull request solve and why should we include it?
I finished highway assignment, but got this error “ cannot activate scenario 11” in ea transit assignment.
 
 
![image](https://user-images.githubusercontent.com/28812722/213528911-6036825d-10f6-4e15-a193-b623273a1bdd.png)

 
This happened when ea assignment was done and tried to export the segment assignment results to shapefile. I tested this function in transit assignment only run.

When emme opens a project, it opens the default emmebank and default scenario. We need to switch to the correct emmebank before we switch to a specific scenario.
