### PR TITLE
fix drive and walk time skimming issue, add v9.4 transit new features

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -957,6 +957,7 @@
     fare_2015_to_2000_deflator = 0.698 #180.20/258.27
     # transit assignment methods
     congested_transit_assignment = true
+    trim_demand_before_congested_transit_assignment = true
     use_ccr = false
     # peaking factor option
     use_peaking_factor = true

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -8,30 +8,35 @@
     length_hours = 3
     highway_capacity_factor = 3
     emme_scenario_id = 11
+    transit_assn_max_iteration = 1
 [[time_periods]]
     name = "am"
     start_hour = 6
     length_hours = 4
     highway_capacity_factor = 3.65
     emme_scenario_id = 12
+    transit_assn_max_iteration = 10
 [[time_periods]]
     name = "md"
     start_hour = 10
     length_hours = 5
     highway_capacity_factor = 5
     emme_scenario_id = 13
+    transit_assn_max_iteration = 1
 [[time_periods]]
     name = "pm"
     start_hour = 15
     length_hours = 4
     highway_capacity_factor = 3.65
     emme_scenario_id = 14
+    transit_assn_max_iteration = 10
 [[time_periods]]
     name = "ev"
     start_hour = 19
     length_hours = 8
     highway_capacity_factor = 8
     emme_scenario_id = 15
+    transit_assn_max_iteration = 1
 
 [logging]
     display_level = "STATUS"
@@ -936,6 +941,7 @@
     output_stop_usage_path = "output_summaries\\stop_usage_{period}.csv"
     output_transit_boardings_path = "output_summaries\\boardings_by_line_{period}.csv"
     output_shapefile_path = "output_summaries\\{period}_assn.shp"
+    output_station_to_station_flow_path = "output_summaries\\{operator}_station_to_station_{set_name}_{period}.txt"
     fares_path = "inputs\\trn\\fares.far"
     fare_matrix_path = "inputs\\trn\\fareMatrix.txt"
     # max expected transfer distance for mode-to-mode transfer fare table generation

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -294,7 +294,7 @@ class CreateTODScenarios(Component):
                         seg.j_node['@wait_pfactor'] = transfer_wait_perception_factor[line.vehicle.mode.id]
                 elif line.vehicle.mode.id =="h":
                     for seg in line.segments():
-                        if seg.i_node['#node_id'] in [2625944]: # hardcode Bart station: 19th street
+                        if seg.i_node['#node_id'] in [2625944, 2625943]: # hardcode Bart station: 19th street, MacArthur
                             seg.i_node['@xboard_nodepen'] = 0.1           
 
             ref_scenario.publish_network(network)

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1229,6 +1229,7 @@ class TransitConfig(ConfigItem):
     classes: Tuple[TransitClassConfig, ...] = Field()
     use_ccr: bool = False
     congested_transit_assignment: bool = False
+    trim_demand_before_congested_transit_assignment: bool = False
     capacitated_transit_assignment: bool = False
     station_capacity_transit_assignment: bool = False
     mask_noncombo_allpen: bool = False

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -216,6 +216,8 @@ class TimePeriodConfig(ConfigItem):
             capacites in the highway network
         emme_scenario_id: scenario ID to use for Emme per-period
             assignment (highway and transit) scenarios
+        transit_assn_max_iteration: max iterations in congested 
+            transit assignment stopping criteria
     """
 
     name: str = Field(max_length=4)
@@ -223,6 +225,7 @@ class TimePeriodConfig(ConfigItem):
     length_hours: float = Field(gt=0)
     highway_capacity_factor: float = Field(gt=0)
     emme_scenario_id: int = Field(ge=1)
+    transit_assn_max_iteration: int = Field(ge=1)
     description: Optional[str] = Field(default="")
 
 
@@ -1222,6 +1225,7 @@ class TransitConfig(ConfigItem):
     output_skim_matrixname_tmpl: str = Field()
     output_transit_boardings_path: str = Field()
     output_shapefile_path: str = Field()
+    output_station_to_station_flow_path: str = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
     use_ccr: bool = False
     congested_transit_assignment: bool = False


### PR DESCRIPTION
- Fix drive and walk time skimming issue. Drive and walk time skims need to be divided by the perception factors which are hardcoded in mode definition.
- Test MSA functionality. To run MSA in transit assignment (iteration >=2), turn 'apply_msa_demand' to true.
- Add node specific transfer penalty to BART MacAuthur station.
- Add 'transit_assn_max_iteration' as a time period variable
- Add export station-to-station flow function.
- Add variable 'trim_demand_before_congested_transit_assignment' to trim the demands based on extended transit assignment
