### PR TITLE
Revert PR "update trk configs"

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -853,7 +853,7 @@
         value_of_time = 29.92
         operating_cost_per_mile = 24.71
         toll = [ "@bridgetoll_sml", "@valuetoll_sml" ]
-        skims = [ "time", "dist", "freeflowtime", "btoll_vsm", "btoll_sml", "btoll_med", "vtoll_vsm", "vtoll_sml", "vtoll_med", "gctime", "cost", ]
+        skims = [ "time", "dist", "freeflowtime", "btoll_vsm", "btoll_sml", "btoll_med", "gctime", "cost", ]
         output_skim_matrixname_tmpl = "{property_name}{class_name}"
         [[highway.classes.demand]]
             source = "truck"
@@ -865,7 +865,7 @@
             source = "truck"
             name = "medtrk"
     [[highway.classes]]
-        name = "lrg"
+        name = "lrgtrk"
         description = "large truck"
         mode_code = "l"
         excluded_links = ["is_auto_only"]
@@ -873,7 +873,7 @@
         operating_cost_per_mile = 24.71
         toll = [ "@bridgetoll_lrg", "@valuetoll_lrg" ]
         pce = 2.0
-        skims = [ "time", "dist", "freeflowtime", "btoll", "vtoll", "gctime", "cost", ]
+        skims = [ "time", "dist", "freeflowtime", "btoll_lrg", "gctime", "cost", ]
         output_skim_matrixname_tmpl = "{property_name}{class_name}"
         [[highway.classes.demand]]
             source = "truck"

--- a/tm2py/components/network/highway/highway_assign.py
+++ b/tm2py/components/network/highway/highway_assign.py
@@ -688,12 +688,9 @@ class AssignmentClass:
             "freeflowtime": "@free_flow_time",
             "btoll": f"@bridgetoll_{group}",
             "vtoll": f"@valuetoll_{group}",
-            # lrgtrk will use "btoll", "vtoll" lookups above
             "btoll_vsm": "@bridgetoll_vsm",
             "btoll_sml": "@bridgetoll_sml",
             "btoll_med": "@bridgetoll_med",
-            "vtoll_vsm": "@valuetoll_vsm",
-            "vtoll_sml": "@valuetoll_sml",
-            "vtoll_med": "@valuetoll_med",
+            "btoll_lrg": "@bridgetoll_lrg",
         }
         return lookup[skim]


### PR DESCRIPTION
Reverts camsys/tm2py#47.

This PR will most likely break the truck model, which reference the truck skims. If the highway truck class name and skim name is changes, so should we change the truck model.