### PR TITLE
use lrgtrk as large truck class name

### DIFF
--- a/tm2py/components/network/highway/highway_network.py
+++ b/tm2py/components/network/highway/highway_network.py
@@ -192,20 +192,20 @@ class PrepareNetwork(Component):
         assert self.controller.iteration == 0
         toll_index = self._get_toll_indices(toll_file_path = self.get_abs_path(toll_file_path))
         for link in network.links():
+            index = int(
+                link["@tollbooth"] * 1000
+                + link["@tollseg"] * 10
+                + link["@useclass"]
+            )
+            data_row = toll_index.get(index)
+            if data_row is None:
+                self.logger.warn(
+                    f"set tolls failed index lookup {index}, link {link.id}",
+                    indent=True,
+                )
+                continue  # tolls will remain at zero
             # set bridgetoll
             if link["@tollbooth"] > 0 and link["@tollbooth"] < valuetoll_start_tollbooth_code:
-                index = int(
-                    link["@tollbooth"] * 1000
-                    + link["@tollseg"] * 10
-                    + link["@useclass"]
-                )
-                data_row = toll_index.get(index)
-                if data_row is None:
-                    self.logger.warn(
-                        f"set tolls failed index lookup {index}, link {link.id}",
-                        indent=True,
-                    )
-                    continue  # tolls will remain at zero
                 for src_veh, dst_veh in zip(src_veh_groups, dst_veh_groups):
                     link[f"@bridgetoll_{dst_veh}"] = (
                         float(data_row[f"toll{time_period.lower()}_{src_veh}"]) * 100


### PR DESCRIPTION
This is one of the alternatives to solve the duplicate `lrg` issue in large truck skim names.
Further tests will be needed to ensure if output skims produced here can be successfully used by the truck model.

- The class name will retain to be `lrgtrk`
- Example large truck skim names will be `BTOLLLRGTRK`, `VTOLLLRGTRK`, etc
- Network link attributes for bridge and value tolls will be `@bridgetoll_lrgtrk` and `@valuetoll_lrgtrk` (instead of `@bridgetoll_lrg` and `@valuetoll_lrg` in previous versions)
- Column names in the input toll files need to be changed accordingly to use `toll{period}_lrgtrk` instead of `toll{period}_lrg`
- Representation of large truck in the vehicle group names lists need to be changed to `lrgtrk` as well.  Restriction to 4 characters therefore need to be loosen to 6 characters in `config.py`
