### PR TITLE
Updating toml files and save results for each iteration for convergen…

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -58,7 +58,7 @@
 	copy_from_examples = false
     host_ip_address = "10.1.36.121"
     ctramp_run_dir = 'D:\MTC\9-county\CTRAMP'
-    sample_rate_iteration = [0.50]
+    sample_rate_iteration = [0.15, 0.30, 1.0]
 
     [household.rideshare_mode_split]
         "taxi"=0.08
@@ -920,10 +920,10 @@
 			modes = ["trk", "lrgtrk"]
 		[[highway.convergence.summary_mode_group]]
 			name = "HOV"
-			modes = ["s2h", "s3h"]
+			modes = ["s2h", "s2l", "s2m", "s2xh", "s3h", "s3l", "s3m", "s3xh"]
 		[[highway.convergence.summary_mode_group]]
 			name = "Drive alone"
-			modes = ["dah"]
+			modes = ["dah", "dal", "dam", "daxh"]
 		
 		
 

--- a/examples/scenario_config.toml
+++ b/examples/scenario_config.toml
@@ -20,19 +20,18 @@
         "highway",
         "prepare_network_transit",
         "transit",
-        "convergence_report"
     ]
     global_iteration_components = [
-        #"home_accessibility",
-        # "household", 
-        # "truck",
-        # "highway",
-        # "transit",
-        #"convergence_report"
+        "home_accessibility",
+         "household", 
+         "truck",
+         "highway",
+         "transit",
+         "convergence_report"
     ]
     final_components = []
     start_iteration = 0
-    end_iteration = 1
+    end_iteration = 3
 
     [run.warmstart]
         warmstart = true

--- a/tm2py/components/network/network_convergence.py
+++ b/tm2py/components/network/network_convergence.py
@@ -26,7 +26,7 @@ class ConvergenceReport(Component):
         self.config =  self.controller.config
 
     def run(self):
-        #self.save_results()
+        self.save_results()
         if self.controller.iteration > 1:
             self.export_summaries()
         


### PR DESCRIPTION
Updates in scenario_config.toml file
-  removing convergence report in the initial components, need to delete that line
-  uncomment global components for the default
-  Set start iteration to 0 and end iteration to 3 as the default

Updates in model_config.toml
-   Set sample rate iteration to [ 0.15, 0.30, 1.0 ]
-   Added income segmentation of convergence reports

Other
- Save results of convergence reports at the end of each iteration. 


