### PR TITLE
add v9.5 transit new features

### DIFF
--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -1526,31 +1526,31 @@
     name = "drive_acc"
     type = "DRIVE"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = "ul1*1"
+    speed_or_time_factor = "ul1*1"
 [[transit.modes]]
     mode_id = "k"
     name = "knrdummy"
     type = "KNR_dummy"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 40.0
+    speed_or_time_factor = 40.0
 [[transit.modes]]
     mode_id = "w"
     name = "walk"
     type = "WALK"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = "ul2*1"
+    speed_or_time_factor = "ul2*1"
 [[transit.modes]]
     mode_id = "a"
     name = "access"
     type = "ACCESS"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = "ul2*1"
+    speed_or_time_factor = "ul2*1"
 [[transit.modes]]
     mode_id = "e"
     name = "egress"
     type = "EGRESS"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = "ul2*1"
+    speed_or_time_factor = "ul2*1"
 [[transit.modes]]
     mode_id = "p"
     name = "pnrdummy"

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -929,6 +929,8 @@
 [transit]
     apply_msa_demand = false
     value_of_time = 12.8 # 16.2*(180.20/227.47) https://github.com/BayAreaMetro/modeling-website/wiki/InflationAssumptions
+    walk_speed = 3.0
+    transit_speed = 30.0 # default transit speed used to calculate transit time in case any links has missing time from highway network
     effective_headway_source = "hdw"
     initial_wait_perception_factor = 1.5
     transfer_wait_perception_factor = 3.0
@@ -961,7 +963,7 @@
     # transit assignment methods
     congested_transit_assignment = true
     trim_demand_before_congested_transit_assignment = true
-    output_trimmed_demand = "output_summaries\\trimmed_demand_{period}_{iteration}.csv"
+    output_trimmed_demand_report_path = "output_summaries\\trimmed_demand_{period}_{iteration}.csv"
     use_ccr = false
     # peaking factor option
     use_peaking_factor = true

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -933,6 +933,7 @@
     initial_wait_perception_factor = 1.5
     transfer_wait_perception_factor = 3.0
     walk_perception_factor = 2.0
+    walk_perception_factor_cbd = 1.0
     drive_perception_factor = 6.0
     max_transfers = 3
     output_skim_path = "skims/transit"
@@ -941,6 +942,7 @@
     output_stop_usage_path = "output_summaries\\stop_usage_{period}.csv"
     output_transit_boardings_path = "output_summaries\\boardings_by_line_{period}.csv"
     output_shapefile_path = "output_summaries\\{period}_assn.shp"
+    output_transit_segment_path = "output_summaries\\transit_segment_{period}.csv"
     output_station_to_station_flow_path = "output_summaries\\{operator}_station_to_station_{set_name}_{period}.txt"
     fares_path = "inputs\\trn\\fares.far"
     fare_matrix_path = "inputs\\trn\\fareMatrix.txt"
@@ -958,6 +960,7 @@
     # transit assignment methods
     congested_transit_assignment = true
     trim_demand_before_congested_transit_assignment = true
+    output_trimmed_demand = "output_summaries\\trimmed_demand_{period}_{iteration}.csv"
     use_ccr = false
     # peaking factor option
     use_peaking_factor = true
@@ -1532,19 +1535,19 @@
     name = "walk"
     type = "WALK"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 3.0
+    speed_miles_per_hour = "ul2*1"
 [[transit.modes]]
     mode_id = "a"
     name = "access"
     type = "ACCESS"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 3.0
+    speed_miles_per_hour = "ul2*1"
 [[transit.modes]]
     mode_id = "e"
     name = "egress"
     type = "EGRESS"
     assign_type = "AUX_TRANSIT"
-    speed_miles_per_hour = 3.0
+    speed_miles_per_hour = "ul2*1"
 [[transit.modes]]
     mode_id = "p"
     name = "pnrdummy"

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -938,6 +938,7 @@
     walk_perception_factor_cbd = 1.0
     drive_perception_factor = 6.0
     max_transfers = 3
+    # output summary paths
     output_skim_path = "skims/transit"
     output_skim_filename_tmpl = "trnskm{time_period}_{set_name}.omx"
     output_skim_matrixname_tmpl = "{property}"
@@ -947,6 +948,7 @@
     output_transit_segment_path = "output_summaries\\transit_segment_{period}.csv"
     output_station_to_station_flow_path = "output_summaries\\{operator}_station_to_station_{set_name}_{period}.txt"
     output_transfer_at_station_path = "output_summaries\\{set_name}_transfer_at_{stop}_{period}"
+    # fare inputs
     fares_path = "inputs\\trn\\fares.far"
     fare_matrix_path = "inputs\\trn\\fareMatrix.txt"
     # max expected transfer distance for mode-to-mode transfer fare table generation
@@ -969,6 +971,13 @@
     use_peaking_factor = true
     am_peaking_factor = 1.219
     pm_peaking_factor = 1.262
+    # timed tranfer nodes
+    timed_transfer_nodes = [2625944, 2625943] # standard network #node_id of Bart stations: 19th street, MacArthur
+    [transit.output_transfer_at_station_node_ids]
+        "12th_street"=2625945 # standard network #node_id
+        "19th street"=2625944 
+        "MacArthur"=2625943
+
 
     [[transit.classes]]
         name = "wlk_trn_wlk"

--- a/examples/model_config.toml
+++ b/examples/model_config.toml
@@ -944,6 +944,7 @@
     output_shapefile_path = "output_summaries\\{period}_assn.shp"
     output_transit_segment_path = "output_summaries\\transit_segment_{period}.csv"
     output_station_to_station_flow_path = "output_summaries\\{operator}_station_to_station_{set_name}_{period}.txt"
+    output_transfer_at_station_path = "output_summaries\\{set_name}_transfer_at_{stop}_{period}"
     fares_path = "inputs\\trn\\fares.far"
     fare_matrix_path = "inputs\\trn\\fareMatrix.txt"
     # max expected transfer distance for mode-to-mode transfer fare table generation

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -238,8 +238,8 @@ class CreateTODScenarios(Component):
             # set fixed guideway times, and initial free flow auto link times
             # TODO: cntype_speed_map to config
             cntype_speed_map = {"CRAIL": 45.0, "HRAIL": 40.0, "LRAIL": 30.0, "FERRY": 15.0}
-            walk_speed = 3.0
-            transit_speed = 30.0
+            walk_speed = self.controller.config.transit.get("walk_speed", 3.0)
+            transit_speed = self.controller.config.transit.get("transit_speed", 30.0)
             for link in network.links():
                 speed = cntype_speed_map.get(link["#cntype"])
                 if speed is None:

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -305,7 +305,7 @@ class CreateTODScenarios(Component):
                         seg.j_node['@wait_pfactor'] = transfer_wait_perception_factor[line.vehicle.mode.id]
                 elif line.vehicle.mode.id =="h":
                     for seg in line.segments():
-                        if seg.i_node['#node_id'] in self.controller.config.timed_transfer_nodes:
+                        if seg.i_node['#node_id'] in self.controller.config.transit.timed_transfer_nodes:
                             seg.i_node['@xboard_nodepen'] = 0            
 
             ref_scenario.publish_network(network)

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -305,8 +305,8 @@ class CreateTODScenarios(Component):
                         seg.j_node['@wait_pfactor'] = transfer_wait_perception_factor[line.vehicle.mode.id]
                 elif line.vehicle.mode.id =="h":
                     for seg in line.segments():
-                        if seg.i_node['#node_id'] in [2625944, 2625943]: # hardcode Bart station: 19th street, MacArthur
-                            seg.i_node['@xboard_nodepen'] = 0.1           
+                        if seg.i_node['#node_id'] in self.controller.config.timed_transfer_nodes:
+                            seg.i_node['@xboard_nodepen'] = 0            
 
             ref_scenario.publish_network(network)
 

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -223,7 +223,7 @@ class CreateTODScenarios(Component):
                     if mode_data['type'] == "DRIVE":
                         mode.speed = "ul1*%s" % drive_perception_factor
                     else:
-                        mode.speed = mode_data['speed_miles_per_hour']
+                        mode.speed = mode_data['speed_or_time_factor']
                 in_vehicle_factors[mode.id] = mode_data.get(
                     "in_vehicle_perception_factor", default_in_vehicle_factor)
                 initial_boarding_penalty[mode.id] = mode_data.get(

--- a/tm2py/components/network/create_tod_scenarios.py
+++ b/tm2py/components/network/create_tod_scenarios.py
@@ -239,6 +239,7 @@ class CreateTODScenarios(Component):
             # TODO: cntype_speed_map to config
             cntype_speed_map = {"CRAIL": 45.0, "HRAIL": 40.0, "LRAIL": 30.0, "FERRY": 15.0}
             walk_speed = 3.0
+            transit_speed = 30.0
             for link in network.links():
                 speed = cntype_speed_map.get(link["#cntype"])
                 if speed is None:
@@ -247,8 +248,11 @@ class CreateTODScenarios(Component):
                         link["@trantime"] = 60 * link.length / speed
                     elif speed > 0:
                         link["@trantime"] = 60 * link.length / speed + link.length * 5 * 0.33
+                    else:
+                        link["@trantime"] = 60 * link.length / transit_speed
                 else:
                     link["@trantime"] = 60 * link.length / speed
+                link.data1 = link["@trantime"]
 
             for line in network.transit_lines():
                 # TODO: may want to set transit line speeds (not necessarily used in the assignment though)

--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -69,11 +69,13 @@ def calc_segment_cost(transit_volume, capacity, segment):
     seated_capacity = line.vehicle.seated_capacity * {0} * 60 / line.headway
     num_seated = min(transit_volume, seated_capacity)
     num_standing = max(transit_volume - seated_capacity, 0)
+
     vcr = transit_volume / capacity
     crowded_factor = (((
            (min_seat_weight+(max_seat_weight-min_seat_weight)*(vcr)**power_seat_weight)*num_seated
            +(min_stand_weight+(max_stand_weight-min_stand_weight)*(vcr)**power_stand_weight)*num_standing
            )/(transit_volume)))
+
     # Toronto implementation limited factor between 1.0 and 10.0
     return max(crowded_factor, 1.0) - 1.0
 """
@@ -1131,13 +1133,13 @@ class TransitAssignment(Component):
                     "type": "MATRIX_CALCULATION",
                     "constraint": None,
                     "result": f'mf"{skim_name}_WACC"',
-                    "expression": f'mf"{skim_name}_WACC"/(({walk_speed}/60)',
+                    "expression": f'mf"{skim_name}_WACC"/({walk_speed}/60)',
                 },
                 {
                     "type": "MATRIX_CALCULATION",
                     "constraint": None,
                     "result": f'mf"{skim_name}_WEGR"',
-                    "expression": f'mf"{skim_name}_WEGR"/(({walk_speed}/60)',
+                    "expression": f'mf"{skim_name}_WEGR"/({walk_speed}/60)',
                 },
             ]
             matrix_calc(spec_list, scenario=scenario, num_processors=num_processors)

--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -1114,7 +1114,7 @@ class TransitAssignment(Component):
             )
 
             drive_perception_factor = self.controller.config.transit.get("drive_perception_factor", 2)
-            walk_speed = 3.0
+            walk_speed = self.controller.config.transit.get("walk_speed")
             # divide drive time by mode specific perception factor to get the actual time
             # for walk time, use walk distance/walk speed
             # because the mode specific perception factors are hardcoded in the mode definition
@@ -1718,7 +1718,7 @@ class TransitAssignment(Component):
         iteration = self.controller.iteration
         modeller = self.controller.emme_manager.modeller()
         num_processors = self._num_processors
-        output_file_name = self.get_abs_path(self.controller.config.transit.output_trimmed_demand)
+        output_file_name = self.get_abs_path(self.controller.config.transit.output_trimmed_demand_report_path)
         matrix_calc = modeller.tool("inro.emme.matrix_calculation.matrix_calculator")
         class_name = [
             "PNR_TRN_WLK",

--- a/tm2py/components/network/transit/transit_network.py
+++ b/tm2py/components/network/transit/transit_network.py
@@ -609,12 +609,12 @@ class ApplyFares(Component):
             self.zone_boundary_crossing_approx(lines, valid_farezones, fare_matrix, fs_data)
         else:
             self.station_to_station_approx(valid_farezones, fare_matrix, zone_nodes, valid_links, network)
-
-        # copy costs from links to segments
-        for line in lines:
-            for segment in line.segments():
-                segment["@invehicle_cost"] = max(segment.link.invehicle_cost, 0)
-                segment["@board_cost"] = max(segment.link.board_cost, 0)
+            # copy costs from links to segments
+            for line in lines:
+                for segment in line.segments():
+                    segment["@invehicle_cost"] = max(segment.link.invehicle_cost, 0)
+                    segment["@board_cost"] = max(segment.link.board_cost, 0)
+        
         network.delete_attribute("LINK", "invehicle_cost")
         network.delete_attribute("LINK", "board_cost")
 
@@ -688,16 +688,15 @@ class ApplyFares(Component):
                         if same_farezone_missing_cost == farezone:
                             self._log.append({"type": "text3", "content": farezone_warning4})
                         same_farezone_missing_cost = farezone
-                    if seg.link:
-                        seg.link.board_cost = max(board_cost, seg.link.board_cost)
+                    seg["@board_cost"] = max(board_cost, seg["@board_cost"])
 
 
                 farezone = int(seg.i_node["@farezone"])
                 # Set the zone-to-zone fare increment from the previous stop
                 if prev_farezone != 0 and farezone != prev_farezone:
                     try:
-                        invehicle_cost = fare_matrix[prev_farezone][farezone] - prev_seg.link.board_cost
-                        prev_seg.link.invehicle_cost = max(invehicle_cost, prev_seg.link.invehicle_cost)
+                        invehicle_cost = fare_matrix[prev_farezone][farezone] - prev_seg["@board_cost"]
+                        prev_seg["@invehicle_cost"] = max(invehicle_cost, prev_seg["@invehicle_cost"])
                     except KeyError:
                         self._log.append({
                             "type": "text3", 

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1121,7 +1121,7 @@ class TransitModeConfig(ConfigItem):
     mode_id: str = Field(min_length=1, max_length=1)
     name: str = Field(max_length=10)
     in_vehicle_perception_factor: Optional[float] = Field(default=None, ge=0)
-    speed_miles_per_hour: Optional[str] = Field(default="")
+    speed_or_time_factor: Optional[str] = Field(default="")
     initial_boarding_penalty: Optional[float] = Field(default=None, ge=0)
     transfer_boarding_penalty: Optional[float] = Field(default=None, ge=0)
     headway_fraction: Optional[float] = Field(default=None, ge=0)
@@ -1134,9 +1134,9 @@ class TransitModeConfig(ConfigItem):
             assert value is not None, "must be specified when assign_type==TRANSIT"
         return value
 
-    @validator("speed_miles_per_hour", always=True)
-    def speed_miles_per_hour_valid(value, values):
-        """Validate speed_miles_per_hour exists if assign_type is AUX_TRANSIT."""
+    @validator("speed_or_time_factor", always=True)
+    def speed_or_time_factor_valid(value, values):
+        """Validate speed_or_time_factor exists if assign_type is AUX_TRANSIT."""
         if "assign_type" in values and values["assign_type"] == "AUX_TRANSIT":
             assert value is not None, "must be specified when assign_type==AUX_TRANSIT"
         return value

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1228,6 +1228,7 @@ class TransitConfig(ConfigItem):
     output_shapefile_path: str = Field()
     output_transit_segment_path: str = Field()
     output_station_to_station_flow_path: str = Field()
+    output_transfer_at_station_path: str = Field()
     output_trimmed_demand: str = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
     use_ccr: bool = False

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1205,6 +1205,7 @@ class TransitConfig(ConfigItem):
     initial_wait_perception_factor: float
     transfer_wait_perception_factor: float
     walk_perception_factor: float
+    walk_perception_factor_cbd: float
     drive_perception_factor: float
     
     max_transfers: int
@@ -1225,7 +1226,9 @@ class TransitConfig(ConfigItem):
     output_skim_matrixname_tmpl: str = Field()
     output_transit_boardings_path: str = Field()
     output_shapefile_path: str = Field()
+    output_transit_segment_path: str = Field()
     output_station_to_station_flow_path: str = Field()
+    output_trimmed_demand: str = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
     use_ccr: bool = False
     congested_transit_assignment: bool = False

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1232,6 +1232,8 @@ class TransitConfig(ConfigItem):
     output_station_to_station_flow_path: str = Field()
     output_transfer_at_station_path: str = Field()
     output_trimmed_demand_report_path: str = Field()
+    timed_transfer_nodes: Tuple[int, ...] = Field()
+    output_transfer_at_station_node_ids: Dict[str, int] = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
     use_ccr: bool = False
     congested_transit_assignment: bool = False

--- a/tm2py/config.py
+++ b/tm2py/config.py
@@ -1199,6 +1199,8 @@ class TransitConfig(ConfigItem):
 
     apply_msa_demand: bool
     value_of_time: float
+    walk_speed: float
+    transit_speed: float
     am_peaking_factor: float
     pm_peaking_factor: float
     effective_headway_source: str
@@ -1229,7 +1231,7 @@ class TransitConfig(ConfigItem):
     output_transit_segment_path: str = Field()
     output_station_to_station_flow_path: str = Field()
     output_transfer_at_station_path: str = Field()
-    output_trimmed_demand: str = Field()
+    output_trimmed_demand_report_path: str = Field()
     classes: Tuple[TransitClassConfig, ...] = Field()
     use_ccr: bool = False
     congested_transit_assignment: bool = False


### PR DESCRIPTION
code changes:
- [x] 1. add different walk perception factors
- [x] 2. report out number of trimmed demand to output_summaries
- [x] 3. report out boardings at stations by access mode to output_summaries
- [x] 4. report out BART to BART transfers at 12th, 19th and MacArthur stations
- [x] 5. fix zone-to-zone fare calculation issue
- [x] 6. add different VDF for PNR mode
- [x] 7. change normalized gap and relative gap in stopping criteria
- [x] 8. remove extra parking penalty at four PNR locations (Glen Park, Lake Merritt, San Bruno, Fruitvale) because of feature NO. 6
- [x] 9. update node-specific transfer boarding time penalties at BART 19th street and Macarthur stations (change from 0.01 to 0)
- [x] 10. add transfer boarding time penalty skim
- [x] 11. code 12th, 19th and MacArthur stations as parameter instead of hard coded in the scripts.

network changes:
- [x] 1. add missing @tollbooth values (via Lasso preprocessing jupyter notebook).
- [x] 2. remove boarding and alighting prohibitions at 19th street and macarthur station (via project cards).
- [x] 3. remove boarding and alighting prohibitions on AM yellow lines (via Emme transaction file).
- [x] 4. fix bus capacity issue on PM PNR dummy route (via Lasso).