### PR TITLE
Additional transit summaries

### DIFF
--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -1778,6 +1778,7 @@ class TransitAssignment(Component):
         # map to used modes in apply fares case
         fare_modes = _defaultdict(lambda: set([]))
         operator_agency_dict = _defaultdict(lambda: set([]))
+        rail_line_id_list = []
         for line in network.transit_lines():
             if use_fares:
                 fare_modes[line["#src_mode"]].add(line.mode.id)
@@ -1787,6 +1788,10 @@ class TransitAssignment(Component):
             operator_id = line.id.split("_")[0]
             agency_id = line.id.split("_")[1]
             operator_agency_dict[operator_id].add(agency_id)
+            # get all rail lines
+            if line["#src_mode"] in ["h", "r"]:
+                if line.id not in rail_line_id_list:
+                    rail_line_id_list.append(line.id)
 
         rail_operator_mode_dict = {
         # mode: network_selection
@@ -1799,12 +1804,12 @@ class TransitAssignment(Component):
                 class_name = access_mode
                 demand_matrix = "mf%s_%s" % (access_mode, period.name)
                 output_file_name = self.get_abs_path(self.controller.config.transit.output_station_to_station_flow_path)
+                sta2sta_spec['analyzed_demand'] = demand_matrix
                 
                 # separate by rail mode
                 for op, cut in rail_operator_mode_dict.items():
                     sta2sta_spec['transit_line_selections']['first_boarding'] = "mode="+",".join(list(fare_modes[cut])) 
                     sta2sta_spec['transit_line_selections']['last_alighting'] = "mode="+",".join(list(fare_modes[cut])) 
-                    sta2sta_spec['analyzed_demand'] = demand_matrix
 
                     output_path = output_file_name.format(operator=op, set_name=access_mode, period=period.name)
                     sta2sta(specification=sta2sta_spec,
@@ -1817,10 +1822,9 @@ class TransitAssignment(Component):
                 all_modes = [fare_modes[m] for m in rail_operator_mode_dict.values()]
                 all_modes_list = [m for sublist in all_modes for m in sublist]
                 sta2sta_spec['transit_line_selections']['first_boarding'] = "mode="+",".join(all_modes_list) 
-                sta2sta_spec['transit_line_selections']['last_alighting'] = "mode="+",".join(all_modes_list) 
-                sta2sta_spec['analyzed_demand'] = demand_matrix
+                sta2sta_spec['transit_line_selections']['last_alighting'] = "mode="+",".join(all_modes_list)
                 
-                output_path = output_file_name.format(operator="all rail", set_name=access_mode, period=period.name)
+                output_path = output_file_name.format(operator="all rails", set_name=access_mode, period=period.name)
                 sta2sta(specification=sta2sta_spec,
                         output_file=output_path,
                         scenario=scenario,
@@ -1831,13 +1835,24 @@ class TransitAssignment(Component):
                 for operator, agency in operator_agency_dict.items():
                     sta2sta_spec['transit_line_selections']['first_boarding'] = "line="+operator+"__"
                     sta2sta_spec['transit_line_selections']['last_alighting'] = "line="+operator+"__"
-                    sta2sta_spec['analyzed_demand'] = demand_matrix
 
                     output_path = output_file_name.format(operator=operator, set_name=access_mode, period=period.name)
                     sta2sta(specification=sta2sta_spec,
                             output_file=output_path,
                             scenario=scenario,
                             append_to_output_file=False,
+                            class_name=class_name)
+
+                # unlinked from rail to rail
+                for from_line in rail_line_id_list:
+                    sta2sta_spec['transit_line_selections']['first_boarding'] = "line="+from_line
+                    sta2sta_spec['transit_line_selections']['last_alighting'] = "line="+from_line
+
+                    output_path = output_file_name.format(operator="unlinked all rails", set_name=access_mode, period=period.name)
+                    sta2sta(specification=sta2sta_spec,
+                            output_file=output_path,
+                            scenario=scenario,
+                            append_to_output_file=True,
                             class_name=class_name)
 
 

--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -1791,6 +1791,7 @@ class TransitAssignment(Component):
 
         with _m.logbook_trace("Writing station-to-station summaries for period %s" % period.name):
             for access_mode in _all_access_modes:
+                # separate by mode
                 for op, cut in operator_dict.items():
                     class_name = access_mode
                     demand_matrix = "mf%s_%s" % (access_mode, period.name)
@@ -1806,6 +1807,21 @@ class TransitAssignment(Component):
                             scenario=scenario,
                             append_to_output_file=False,
                             class_name=class_name)
+                
+                # for all rails
+                class_name = access_mode
+                demand_matrix = "mf%s_%s" % (access_mode, period.name)
+                sta2sta_spec['transit_line_selections']['first_boarding'] = "mode="+",".join([fare_modes[m] for m in operator_dict.values()]) 
+                sta2sta_spec['transit_line_selections']['last_alighting'] = "mode="+",".join([fare_modes[m] for m in operator_dict.values()]) 
+                sta2sta_spec['analyzed_demand'] = demand_matrix
+                
+                output_file_name = self.get_abs_path(self.controller.config.transit.output_station_to_station_flow_path)
+                output_path = output_file_name.format(operator="all rail", set_name=access_mode, period=period.name)
+                sta2sta(specification=sta2sta_spec,
+                        output_file=output_path,
+                        scenario=scenario,
+                        append_to_output_file=False,
+                        class_name=class_name)
 
 
     def export_transfer_at_stops(self, network, period, scenario):

--- a/tm2py/components/network/transit/transit.py
+++ b/tm2py/components/network/transit/transit.py
@@ -1811,8 +1811,10 @@ class TransitAssignment(Component):
                 # for all rails
                 class_name = access_mode
                 demand_matrix = "mf%s_%s" % (access_mode, period.name)
-                sta2sta_spec['transit_line_selections']['first_boarding'] = "mode="+",".join([fare_modes[m] for m in operator_dict.values()]) 
-                sta2sta_spec['transit_line_selections']['last_alighting'] = "mode="+",".join([fare_modes[m] for m in operator_dict.values()]) 
+                all_modes = [fare_modes[m] for m in operator_dict.values()]
+                all_modes_list = [m for sublist in all_modes for m in sublist]
+                sta2sta_spec['transit_line_selections']['first_boarding'] = "mode="+",".join(all_modes_list) 
+                sta2sta_spec['transit_line_selections']['last_alighting'] = "mode="+",".join(all_modes_list) 
                 sta2sta_spec['analyzed_demand'] = demand_matrix
                 
                 output_file_name = self.get_abs_path(self.controller.config.transit.output_station_to_station_flow_path)


### PR DESCRIPTION

## What existing problem does the pull request solve and why should we include it?

Yue wrote some code to output station-to-station boardings. They seem to be segmented by mode – with two sets of files BART and “Caltrain,” though Caltrain includes other rail operators. This is because Caltrain and the other rail operators all have source mode as “r”. 

Adding summaries for all rail trip – so first boarding/last alighting on any rail (“h” or “r”) to link trips between BART and Caltrain or other rail operators

## What is the testing plan?

@mnbina I have not tested this, but it should work

 - [ ] Code for this PR produces results as expected
